### PR TITLE
[ENHANCEMENT] Pulling images from inventory file

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -6,19 +6,25 @@ Config.craftingBenches = {
     {id = "testId", coords = vector3(429.16, 6478.77, 28.79), heading = 140.76},
 }
 
+--[[
+Make sure to change the image path to your inventory image file. Default is lj-inventory, you can change it to qb-inventory by doing this example below:
+    https://cfx-nui-qb-inventory/html/images/radio.png
+]]
+
+
 -- Recipes that come with every workbench
 Config.defaultRecipes = {
     radio = {
         item = "radio",
         label = "Radio",
-        image = "radio.png",
+        image = "https://cfx-nui-lj-inventory/html/images/radio.png", 
         isAttachment = false,
         threshold = 0,
         points = 1,
         components = {
-            {item = "aluminum", label = "Aluminum", amount = 10, image = "aluminum.png"},
-            {item = "rubber", label = "Rubber", amount = 10, image = "rubber.png"},
-            {item = "plastic", label = "Plastic", amount = 10, image = "plastic.png"},
+            {item = "aluminum", label = "Aluminum", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/aluminum.png"},
+            {item = "rubber", label = "Rubber", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/rubber.png"},
+            {item = "plastic", label = "Plastic", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/plastic.png"},
         }
     },
 }
@@ -28,14 +34,14 @@ Config.blueprintRecipes = {
     advancedlockpick = {
         item = "advancedlockpick",
         label = "Advanced Lockpick",
-        image = "advancedlockpick.png",
+        image = "https://cfx-nui-lj-inventory/html/images/advancedlockpick.png",
         isAttachment = false,
         points = 1,
         components = {
-            {item = "aluminum", label = "Aluminum", amount = 10, image = "aluminum.png"},
-            {item = "rubber", label = "Rubber", amount = 10, image = "rubber.png"},
-            {item = "plastic", label = "Plastic", amount = 10, image = "plastic.png"},
+            {item = "aluminum", label = "Aluminum", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/aluminum.png"},
+            {item = "rubber", label = "Rubber", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/rubber.png"},
+            {item = "plastic", label = "Plastic", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/plastic.png"},
         },
-        blueprintImage = "blueprint.png"
+        blueprintImage = "https://cfx-nui-lj-inventory/html/images/blueprint.png"
     },
 }

--- a/html/script.js
+++ b/html/script.js
@@ -94,7 +94,7 @@ function displayRecipe(craftData, isBlueprint) {
     craftData.components.forEach(item => {
         componentEl += 
         `<div class="component">
-            <img src="images/${item.image}" alt="">
+            <img src="${item.image}" alt="">
             <div class="component-text">${item.label}: ${item.amount}</div>
         </div>`;
     });
@@ -104,7 +104,7 @@ function displayRecipe(craftData, isBlueprint) {
             <div class="recipe-img">
                 <div class="recipe-text">${craftData.label}</div>
                 <div class="craft-img">
-                    <img src="images/${craftData.image}">
+                    <img src="${craftData.image}">
                 </div>
             </div>
             <div class="recipe-components">
@@ -128,7 +128,7 @@ function addBlueprint(blueprint) {
         emptySlot.append(`
             <div class="blueprint-text" data-blueprint="${blueprint.item}">${blueprint.label} Blueprint</div>
             <div class="craft-img">
-                <img src="images/${blueprint.blueprintImage}">
+                <img src="${blueprint.blueprintImage}">
             </div>`
         )
     }


### PR DESCRIPTION
The method that I changed for this pull request reads the images directly from the inventory image path rather than the image folder in glow_crafting. This makes it so that you do not have to have images in 2 different places. 

I tested this and can confirm that this method works. I also added a little example in the config in case anyone is using qb-inventory. 


Hope this helps :) 