### PR TITLE
Added Bench Specific Crafting and BoxZones

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -17,7 +17,7 @@ end
 local function getThresholdRecipes(craftingRep, attachmentRep)
     local playerDefaultRecipes = {}
     for k, v in pairs(Config.defaultRecipes) do
-        if v.benchId == currentBenchId then
+        if v.benchId == currentBenchId or not v.benchId then
             if v.isAttachment then
                 if attachmentRep >= v.threshold then
                     playerDefaultRecipes[#playerDefaultRecipes + 1] = v

--- a/client.lua
+++ b/client.lua
@@ -107,23 +107,25 @@ local function spawnObj(model, coords, heading, objExists)
             distance = 1.5
         })
     else
-        exports['qb-target']:AddBoxZone("CraftingBench", coords, 0.8, 1.2, {
-            name = "CraftingBench",
-            heading = heading,
-            debugPoly = false,
-            minZ = coords.z-1,
-            maxZ = coords.z+1,
-        }, {
-            options = { {
-                icon = "fa-solid fa-hammer",
-                label = "Craft",
-                action = function()
-                    TriggerServerEvent("glow_crafting_sv:getWorkBenchData")
-                end
-            }
-            },
-            distance = 1.5
-        })
+        if model == 'prop_toolchest_05' then
+            exports['qb-target']:AddBoxZone("BaseCrafting", coords, 0.8, 1.2, {
+                name = "BaseCrafting",
+                heading = heading,
+                debugPoly = false,
+                minZ = coords.z-1,
+                maxZ = coords.z+1,
+            }, {
+                options = { {
+                    icon = "fa-solid fa-hammer",
+                    label = "Craft",
+                    action = function()
+                        TriggerServerEvent("glow_crafting_sv:getWorkBenchData")
+                    end
+                }
+                },
+                distance = 1.5
+            })
+        end
     end
 
    return object

--- a/client.lua
+++ b/client.lua
@@ -17,13 +17,15 @@ end
 local function getThresholdRecipes(craftingRep, attachmentRep)
     local playerDefaultRecipes = {}
     for k, v in pairs(Config.defaultRecipes) do
-        if v.isAttachment then
-            if attachmentRep >= v.threshold then
-                playerDefaultRecipes[#playerDefaultRecipes + 1] = v
-            end
-        else
-            if craftingRep >= v.threshold then
-                playerDefaultRecipes[#playerDefaultRecipes + 1] = v
+        if v.benchId == currentBenchId then
+            if v.isAttachment then
+                if attachmentRep >= v.threshold then
+                    playerDefaultRecipes[#playerDefaultRecipes + 1] = v
+                end
+            else
+                if craftingRep >= v.threshold then
+                    playerDefaultRecipes[#playerDefaultRecipes + 1] = v
+                end
             end
         end
     end
@@ -156,7 +158,9 @@ RegisterNetEvent("glow_crafting_cl:openCraftingBench", function(craftingBenchDat
         local blueprintRecipes = {}
         for k, v in pairs(craftingBenchData.blueprints) do
             if Config.blueprintRecipes[v] then
-                blueprintRecipes[#blueprintRecipes + 1] = Config.blueprintRecipes[v]
+                if Config.blueprintRecipes[v].benchId == currentBenchId then
+                    blueprintRecipes[#blueprintRecipes + 1] = Config.blueprintRecipes[v]
+                end
             end
         end
 

--- a/config.lua
+++ b/config.lua
@@ -4,7 +4,11 @@ Config = {}
 
 Config.craftingBenches = {
     {id = "pbase1", coords = vector3(97.51, 6618.9, 31.43), heading = 134.43, objExists = true, prop = 'prop_toolchest_05'},
-    {id = "testId", coords = vector3(429.16, 6478.77, 28.79), heading = 140.76, objExists = false, prop = 'gr_prop_gr_bench_04b'},
+    {id = "pspawn1", coords = vector3(429.16, 6478.77, 28.79), heading = 140.76, objExists = false, prop = 'gr_prop_gr_bench_04b'},
+}
+
+Config.benchList = {
+    base = "pbase1" or "pspawn1",
 }
 
 --[[
@@ -18,7 +22,7 @@ Config.defaultRecipes = {
         item = "radio",
         label = "Radio",
         image = "https://cfx-nui-qb-inventory/html/images/radio.png",
-        benchId = false,
+        benchId = Config.benchList.base,
         isAttachment = false,
         threshold = 0,
         points = 1,
@@ -36,7 +40,7 @@ Config.blueprintRecipes = {
         item = "advancedlockpick",
         label = "Advanced Lockpick",
         image = "https://cfx-nui-qb-inventory/html/images/advancedlockpick.png",
-        benchId = "testId",
+        benchId = Config.benchList.base,
         isAttachment = false,
         points = 1,
         components = {

--- a/config.lua
+++ b/config.lua
@@ -6,25 +6,20 @@ Config.craftingBenches = {
     {id = "testId", coords = vector3(429.16, 6478.77, 28.79), heading = 140.76},
 }
 
---[[
-Make sure to change the image path to your inventory image file. Default is lj-inventory, you can change it to qb-inventory by doing this example below:
-    https://cfx-nui-qb-inventory/html/images/radio.png
-]]
-
-
 -- Recipes that come with every workbench
 Config.defaultRecipes = {
     radio = {
         item = "radio",
         label = "Radio",
-        image = "https://cfx-nui-lj-inventory/html/images/radio.png", 
+        image = "radio.png",
+        benchId = "testId",
         isAttachment = false,
         threshold = 0,
         points = 1,
         components = {
-            {item = "aluminum", label = "Aluminum", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/aluminum.png"},
-            {item = "rubber", label = "Rubber", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/rubber.png"},
-            {item = "plastic", label = "Plastic", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/plastic.png"},
+            {item = "aluminum", label = "Aluminum", amount = 10, image = "aluminum.png"},
+            {item = "rubber", label = "Rubber", amount = 10, image = "rubber.png"},
+            {item = "plastic", label = "Plastic", amount = 10, image = "plastic.png"},
         }
     },
 }
@@ -34,14 +29,15 @@ Config.blueprintRecipes = {
     advancedlockpick = {
         item = "advancedlockpick",
         label = "Advanced Lockpick",
-        image = "https://cfx-nui-lj-inventory/html/images/advancedlockpick.png",
+        image = "advancedlockpick.png",
+        benchId = "testId",
         isAttachment = false,
         points = 1,
         components = {
-            {item = "aluminum", label = "Aluminum", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/aluminum.png"},
-            {item = "rubber", label = "Rubber", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/rubber.png"},
-            {item = "plastic", label = "Plastic", amount = 10, image = "https://cfx-nui-lj-inventory/html/images/plastic.png"},
+            {item = "aluminum", label = "Aluminum", amount = 10, image = "aluminum.png"},
+            {item = "rubber", label = "Rubber", amount = 10, image = "rubber.png"},
+            {item = "plastic", label = "Plastic", amount = 10, image = "plastic.png"},
         },
-        blueprintImage = "https://cfx-nui-lj-inventory/html/images/blueprint.png"
+        blueprintImage = "blueprint.png"
     },
 }

--- a/config.lua
+++ b/config.lua
@@ -1,25 +1,31 @@
 Config = {}
 
-Config.prop = 'gr_prop_gr_bench_04b'
+-- Config.prop = 'gr_prop_gr_bench_04b'
 
 Config.craftingBenches = {
-    {id = "testId", coords = vector3(429.16, 6478.77, 28.79), heading = 140.76},
+    {id = "pbase1", coords = vector3(97.51, 6618.9, 31.43), heading = 134.43, objExists = true, prop = 'prop_toolchest_05'},
+    {id = "testId", coords = vector3(429.16, 6478.77, 28.79), heading = 140.76, objExists = false, prop = 'gr_prop_gr_bench_04b'},
 }
+
+--[[
+Make sure to change the image path to your inventory image file. Default is lj-inventory, you can change it to qb-inventory by doing this example below:
+    https://cfx-nui-qb-inventory/html/images/radio.png
+]]
 
 -- Recipes that come with every workbench
 Config.defaultRecipes = {
     radio = {
         item = "radio",
         label = "Radio",
-        image = "radio.png",
-        benchId = "testId",
+        image = "https://cfx-nui-qb-inventory/html/images/radio.png",
+        benchId = false,
         isAttachment = false,
         threshold = 0,
         points = 1,
         components = {
-            {item = "aluminum", label = "Aluminum", amount = 10, image = "aluminum.png"},
-            {item = "rubber", label = "Rubber", amount = 10, image = "rubber.png"},
-            {item = "plastic", label = "Plastic", amount = 10, image = "plastic.png"},
+            {item = "aluminum", label = "Aluminum", amount = 10, image = "https://cfx-nui-qb-inventory/html/images/aluminum.png"},
+            {item = "rubber", label = "Rubber", amount = 10, image = "https://cfx-nui-qb-inventory/html/images/rubber.png"},
+            {item = "plastic", label = "Plastic", amount = 10, image = "https://cfx-nui-qb-inventory/html/images/plastic.png"},
         }
     },
 }
@@ -29,15 +35,15 @@ Config.blueprintRecipes = {
     advancedlockpick = {
         item = "advancedlockpick",
         label = "Advanced Lockpick",
-        image = "advancedlockpick.png",
+        image = "https://cfx-nui-qb-inventory/html/images/advancedlockpick.png",
         benchId = "testId",
         isAttachment = false,
         points = 1,
         components = {
-            {item = "aluminum", label = "Aluminum", amount = 10, image = "aluminum.png"},
-            {item = "rubber", label = "Rubber", amount = 10, image = "rubber.png"},
-            {item = "plastic", label = "Plastic", amount = 10, image = "plastic.png"},
+            {item = "aluminum", label = "Aluminum", amount = 10, image = "https://cfx-nui-qb-inventory/html/images/aluminum.png"},
+            {item = "rubber", label = "Rubber", amount = 10, image = "https://cfx-nui-qb-inventory/html/images/rubber.png"},
+            {item = "plastic", label = "Plastic", amount = 10, image = "https://cfx-nui-qb-inventory/html/images/plastic.png"},
         },
-        blueprintImage = "blueprint.png"
+        blueprintImage = "https://cfx-nui-qb-inventory/html/images/blueprint.png"
     },
 }


### PR DESCRIPTION
Added a check for benchId and whether or not the prop exists. 
Gives the ability to either limit recipes to specific benches or all benches.
Can now easily fully replace qb/lj-inventory crafting with using base gta props.